### PR TITLE
Fixed race conditions

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -91,7 +91,7 @@ assert() {
     (( tests_ran++ ))
     [[ -n "$DISCOVERONLY" ]] && return
     expected=$(echo -e "x${2:-}") # x required to overwrite older results
-    result=$(eval 2>/dev/null "$1" <<< ${3:-})
+    result=$(echo -e "$(eval 2>/dev/null "$1" <<< ${3:-})")
     # Note: $expected is already decorated
     if [[ "x$result" == "$expected" ]]; then
         [[ -n "$DEBUG" ]] && echo -n .

--- a/tests.sh
+++ b/tests.sh
@@ -14,6 +14,7 @@ assert "echo 1;
 echo 2      # ^" "1\n2"                 # semicolon required!
 assert 'echo " * "' " * "               # don't let the shell evaluate arguments
 assert "echo '%s --'" "%s --"           # don't escape user content
+assert "echo \"foo\nbar\"" "foo\nbar"   # interpretation of backslash escape
 assert_end demo
 
 _clean() {


### PR DESCRIPTION
assert.sh fail in a couple cases

1) using assert, if your tested command has as parameter a string with a space separated asterisk then the asterisk will be evaluated by the shell.

2) using assert, if your tested command has as parameter a string with characters that have a special meaning in printf, printf will output something unexpected

I suspect that in assert_raises
(eval $1 <<< ${3:-}) > /dev/null 2>&1
should really be written as
(eval "$1" <<< ${3:-}) > /dev/null 2>&1

but I can't produce a test case similar to 1)

p.s.
I couldn't figure out the meaning of "x required to overwrite older results": is it still needed once printf is gone?
