### PR TITLE
Remove bc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: bash
 script: bash tests.sh
-before_install:
-    - sudo apt-get install bc

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@
 :Version: 1.0.2
 :Author: Robert Lehmann
 :License: LGPLv3
-:Requirements: `bc -- an arbitrary precision calculator language
-               <http://www.gnu.org/software/bc/manual/bc.html>`_
-               (installed on all POSIX-compliant systems)
 
 .. image:: https://travis-ci.org/lehmannro/assert.sh.svg?branch=master
    :target: https://travis-ci.org/lehmannro/assert.sh

--- a/assert.sh
+++ b/assert.sh
@@ -81,7 +81,7 @@ assert_end() {
     [[ -n "$DEBUG" ]] && echo
     # to get report_time split tests_time on 2 substrings:
     #   ${tests_time:0:${#tests_time}-9} - seconds
-    #   ${tests_time:${#tests_time}-9:3} - miliseconds
+    #   ${tests_time:${#tests_time}-9:3} - milliseconds
     [[ -z "$INVARIANT" ]] \
         && report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:3}s" \
         || report_time=

--- a/assert.sh
+++ b/assert.sh
@@ -79,8 +79,11 @@ assert_end() {
     tests="$tests_ran ${*:+$* }tests"
     [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
     [[ -n "$DEBUG" ]] && echo
+    # to get report_time split tests_time on 2 substrings:
+    #   ${tests_time:0:${#tests_time}-9} - seconds
+    #   ${tests_time:${#tests_time}-9:3} - miliseconds
     [[ -z "$INVARIANT" ]] \
-        && report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:${#tests_time}-7}s" \
+        && report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:3}s" \
         || report_time=
 
     if [[ "$tests_failed" -eq 0 ]]; then

--- a/assert.sh
+++ b/assert.sh
@@ -75,7 +75,8 @@ assert_end() {
     tests_endtime="$(date +%s%N)"
     # required visible decimal place for seconds (leading zeros if needed)
     local tests_time="$( \
-        printf "%010d" "$(( ${tests_endtime} - ${tests_starttime} ))")"  # in ns
+        printf "%010d" "$(( ${tests_endtime/%N/000000000} 
+                            - ${tests_starttime/%N/000000000} ))")"  # in ns
     tests="$tests_ran ${*:+$* }tests"
     [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
     [[ -n "$DEBUG" ]] && echo

--- a/assert.sh
+++ b/assert.sh
@@ -67,18 +67,20 @@ _assert_reset() {
     tests_ran=0
     tests_failed=0
     tests_errors=()
-    tests_starttime="$(date +%s.%N)" # seconds_since_epoch.nanoseconds
+    tests_starttime="$(date +%s%N)" # nanoseconds_since_epoch
 }
 
 assert_end() {
     # assert_end [suite ..]
-    tests_endtime="$(date +%s.%N)"
+    tests_endtime="$(date +%s%N)"
+    # required visible decimal place for seconds (leading zeros if needed)
+    local tests_time="$( \
+        printf "%010d" "$(( ${tests_endtime} - ${tests_starttime} ))")"  # in ns
     tests="$tests_ran ${*:+$* }tests"
     [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
     [[ -n "$DEBUG" ]] && echo
-    [[ -z "$INVARIANT" ]] && report_time=" in $(bc \
-        <<< "${tests_endtime%.N} - ${tests_starttime%.N}" \
-        | sed -e 's/\.\([0-9]\{0,3\}\)[0-9]*/.\1/' -e 's/^\./0./')s" \
+    [[ -z "$INVARIANT" ]] \
+        && report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:${#tests_time}-7}s" \
         || report_time=
 
     if [[ "$tests_failed" -eq 0 ]]; then

--- a/tests.sh
+++ b/tests.sh
@@ -47,6 +47,13 @@ assert "_clean STOP=1; assert_raises false; assert_end" \
 # runtime statistics (omission of -i)
 assert_raises "_clean INVARIANT=;
 assert_end | egrep 'all 0 tests passed in ([0-9]|[0-9].[0-9]{3})s'"
+# date with no nanosecond support
+date() {         # date mock
+    echo "123N"
+}
+assert '_clean DEBUG=1 INVARIANT=; tests_starttime="0N"; assert_end' \
+       '\nall 0 tests passed in 123.000s.'
+unset -f date  # bring back original date
 assert_end output
 
 # assert_end exit code is the number of failures


### PR DESCRIPTION
As `bc` isn't default installed on many OS's, I think, we could replace it with a more sophisticated method:
- get time in nanoseconds,
- split it on seconds part `${time:0:${#time}-9}` and microseconds part <del>`${time:${#time}-9:${#time}-7}`</del> `${time:${#time}-9:3}`.
