### PR TITLE
Fix for assert & assert_raises when nounset flag set

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -111,7 +111,7 @@ assert() {
     result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<< "$result")"
     [[ -z "$result" ]] && result="nothing" || result="\"$result\""
     [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
-    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+    _assert_fail "expected $expected${_indent}got $result" "$1" "${3:-}"
 }
 
 assert_raises() {

--- a/assert.sh
+++ b/assert.sh
@@ -125,7 +125,7 @@ assert_raises() {
         [[ -z "$DEBUG" ]] || echo -n .
         return
     fi
-    _assert_fail "program terminated with code $status instead of $expected" "$1" "$3"
+    _assert_fail "program terminated with code $status instead of $expected" "$1" "${3:-}"
 }
 
 _assert_fail() {


### PR DESCRIPTION
When running with `set -o nounset`, the `assert()` and `assert_raises()` functions failed if no stdin value was provided.